### PR TITLE
chore: update compatibility date

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "zksnark-sudoku"
-compatibility_date = "2024-07-29"
+compatibility_date = "2025-04-02"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./packages/app/.vercel/output/static"
 


### PR DESCRIPTION

This PR updates the `compatibility_date` in the `wrangler.toml` file to address an issue encountered on the Sindri endpoint:

````
Error: No such module "__next-on-pages-dist__/functions/api/async_hooks".
  imported from "__next-on-pages-dist__/functions/api/sindri.func.js"
````

This error was caused by underlying changes in the Vercel versions used by the @cloudflare/next-on-pages library during the build process. Updating the compatibility date resolves the issue.

Check it here: https://fix.zksnark-sudoku.pages.dev/